### PR TITLE
Add warning message when login as admin

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -6,15 +6,15 @@ class SessionsController < ApplicationController
   end
 
   def create
-    @current_user = User.find_by email: params[:user][:email], role: :user
-    if @current_user&.authenticate(params[:user][:password])
-      remember_user
-      flash[:success] = t("logged_in_as", name: @current_user.first_name)
-      redirect_to root_url
+    @current_user = User.find_by email: params[:user][:email]
+    if @current_user&.admin?
+      flash[:warning] = t("admins_not_allowed")
+      redirect_to action: :new
+    elsif @current_user&.authenticate(params[:user][:password])
+      handle_log_in
     else
       flash[:danger] = t("email_password_invalid")
-      use_layout_auth
-      render :new
+      redirect_to action: :new
     end
   end
 
@@ -28,6 +28,12 @@ class SessionsController < ApplicationController
   end
 
   private
+
+  def handle_log_in
+    remember_user
+    flash[:success] = t("logged_in_as", name: @current_user.first_name)
+    redirect_to root_url
+  end
 
   def remember_user
     session[:user_id] = @current_user.id

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -56,6 +56,7 @@ en:
   logged_in_as: "Logged in as %{name}"
   email_password_invalid: "Either email or password is invalid"
   logged_out: "Successfully logged out"
+  admins_not_allowed: "Sorry but admins are not allowed"
 
   activerecord:
     attributes:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -61,6 +61,7 @@ vi:
   logged_in_as: "Đăng nhập thành công với %{name}"
   email_password_invalid: "Địa chỉ email hoặc mật khẩu không đúng"
   logged_out: "Đăng xuất thành công"
+  admins_not_allowed: "Xin lỗi bạn, người quản trị không thể truy cập tính năng này"
 
   activerecord:
     attributes:


### PR DESCRIPTION
## Related Tickets
- [#43625](https://edu-redmine.sun-asterisk.vn/issues/43625)

## WHAT
- Thêm hiển thị thông báo khi đăng nhập bằng tài khoản admin vào trang /login cho user
## HOW
- Kiểm tra nếu tài khoản đăng nhập là role admin thì hiển thị thông báo đăng nhập thất bại vì role không đúng và chuyển về trang đăng nhập.
## WHY
- Nhằm mô tả rõ hơn thông báo lỗi khi đăng nhập vào trang /login của user
## Evidence (Screenshot or Video)
- Passed `framgia-ci run --local` ![Screenshot from 2021-11-24 11-42-11](https://user-images.githubusercontent.com/91654386/143176162-a341d7fb-1969-4e7e-8ebe-bf9ed02a06ed.png)

