### PR TITLE
Fix img links

### DIFF
--- a/app/views/layouts/_product_card.html.erb
+++ b/app/views/layouts/_product_card.html.erb
@@ -6,7 +6,7 @@
   <div class="featured__item">
     <div
             class="featured__item__pic set-bg"
-            data-setbg="img/featured/feature-1.jpg"
+            data-setbg="/img/featured/feature-1.jpg"
           >
       <ul class="featured__item__pic__hover">
         <li>

--- a/app/views/layouts/_product_carousel.html.erb
+++ b/app/views/layouts/_product_carousel.html.erb
@@ -1,6 +1,6 @@
 <%= link_to("#", class: "latest-product__item") do %>
   <div class="latest-product__item__pic">
-    <img src="img/latest-product/lp-1.jpg" alt="" />
+    <img src="/img/latest-product/lp-1.jpg" alt="" />
   </div>
   <div class="latest-product__item__text">
     <h5><%= product.name %></h5>


### PR DESCRIPTION
## Related Tickets
- [#43804](https://edu-redmine.sun-asterisk.vn/issues/43804)

## WHAT
- Fix đường dẫn `src` của thẻ `img` ở trang index của static pages.
## HOW
- Thêm dấu `/` vào các đường dẫn này.
## WHY (optional)
- Do URL có locale nên phải thêm dấu `/` để tìm đến ảnh trong folder `/public`
## Evidence (Screenshot or Video)
- Passed rubocop: ![passed-rubocop](https://user-images.githubusercontent.com/91654386/143425292-6838595d-84ed-42fb-8fbe-b77aa51d989b.png)


