### PR TITLE
Admin orders index

### DIFF
--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -1,0 +1,13 @@
+class Admin::OrdersController < Admin::BaseController
+  before_action :load_orders_paginate, only: :index
+
+  def index; end
+
+  private
+
+  def load_orders_paginate
+    @orders = Order.order_by_status.order_by_last_updated
+                   .page(params[:page])
+                   .per(Settings.paginate.per_page)
+  end
+end

--- a/app/helpers/admin/orders_helper.rb
+++ b/app/helpers/admin/orders_helper.rb
@@ -1,0 +1,28 @@
+module Admin::OrdersHelper
+  def render_order_header attribute
+    if attribute == "user_id"
+      User.human_attribute_name "email"
+    else
+      Order.human_attribute_name attribute
+    end
+  end
+
+  def render_order_attribute order, name
+    if name == "status"
+      render_order_statuses order
+    elsif name == "user_id"
+      order.user_email
+    elsif Order.datetime_attributes.include?(name)
+      l order.send(name), format: :long
+    elsif Order.currency_attributes.include?(name)
+      translate_price order.send(name)
+    else
+      order.send(name)
+    end
+  end
+
+  def render_order_statuses order
+    select_tag :status, options_for_select(Order.statuses, order.status_value),
+               class: "form-select select-status"
+  end
+end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -5,4 +5,29 @@ class Order < ApplicationRecord
   belongs_to :user
   has_many :order_items, dependent: :destroy
   has_many :products, through: :order_items, dependent: :destroy
+  scope :order_by_status, ->{order :status}
+  scope :order_by_last_updated, ->{order updated_at: :desc}
+  delegate :email, to: :user, prefix: :user
+
+  def status_value
+    Order.statuses[status]
+  end
+
+  class << self
+    def hidden_attributes
+      %w(user_id)
+    end
+
+    def shown_attributes
+      attribute_names.reject{|name| hidden_attributes.include? name}
+    end
+
+    def datetime_attributes
+      %w(created_at updated_at)
+    end
+
+    def currency_attributes
+      %w(total_price)
+    end
+  end
 end

--- a/app/views/admin/layouts/_sidebar.html.erb
+++ b/app/views/admin/layouts/_sidebar.html.erb
@@ -18,6 +18,13 @@
     <%= t ".pages" %>
   </div>
   <li class="nav-item">
+    <%= link_to admin_orders_path, class: "nav-link" do %>
+      <i class="fab fa-fw fa-wpforms"></i>
+      <span><%= t ".orders" %></span>
+    <% end %>
+  </li>
+  <hr class="sidebar-divider">
+  <li class="nav-item">
     <%= link_to admin_logout_path, class: "nav-link" do %>
       <i class="fas fa-sign-out-alt"></i>
       <span><%= t ".logout" %></span>

--- a/app/views/admin/orders/_order.html.erb
+++ b/app/views/admin/orders/_order.html.erb
@@ -1,0 +1,11 @@
+<tr>
+  <% Order.attribute_names.each do |name| %>
+    <td>
+      <%= render_order_attribute order, name %>
+    </td>
+  <% end %>
+  <td>
+    <%= link_to t(".update"), "#", method: :put, class: "btn btn-primary btn-update disabled" %>
+    <%= link_to t(".view_details"), "#", class: "btn btn-success" %>
+  </td>
+</tr>

--- a/app/views/admin/orders/index.html.erb
+++ b/app/views/admin/orders/index.html.erb
@@ -1,0 +1,28 @@
+<% provide :title, t("admin.layouts.sidebar.orders") %>
+<h1><%= t "admin.layouts.sidebar.orders" %></h1>
+<div class="row">
+  <div class="col-lg-12 mb-4">
+    <div class="card">
+      <div class="table-responsive">
+        <table class="table align-items-center table-flush">
+          <thead class="thead-light text-center">
+            <tr>
+              <% Order.attribute_names.each do |name| %>
+                <th>
+                  <%= render_order_header name %>
+                </th>
+              <% end %>
+              <th><%= t(".actions") %></th>
+            </tr>
+          </thead>
+          <tbody>
+            <%= render @orders %>
+          </tbody>
+        </table>
+      </div>
+      <div class="row justify-content-center">
+        <%= paginate @orders %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,7 +37,7 @@ en:
         dashboard: "Dashboard"
         pages: "Pages"
         logout: "Logout"
-        choose_language: "Choose your language"
+        orders: "Manage orders"
       topbar:
         choose_language: "Choose your language"
     sessions:
@@ -46,6 +46,12 @@ en:
         email: "Email"
         password: "Password"
         remember_me: "Remember me"
+    orders:
+      order:
+        update: "Update"
+        view_details: "Details"
+      index:
+        actions: "Actions"
     logged_in_as: "Logged in as %{name}"
     log_in_failed: "Either email or password is incorrect"
     users_not_allowed: "Sorry but only admins are allowed"

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -37,7 +37,7 @@ vi:
         dashboard: "Bảng điều khiển"
         pages: "Trang"
         logout: "Đăng xuất"
-        choose_language: "Chọn ngôn ngữ của bạn"
+        orders: "Quản lý đơn hàng"
     topbar:
       choose_language: "Choose your language"
     sessions:
@@ -46,6 +46,12 @@ vi:
         email: "Địa chỉ email"
         password: "Mật khẩu"
         remember_me: "Ghi nhớ đăng nhập"
+    orders:
+      order:
+        update: "Sửa"
+        view_details: "Xem"
+      index:
+        actions: "Hành động"
     logged_in_as: "Đăng nhập thành công dưới tên %{name}"
     log_in_failed: "Địa chỉ email hoặc mật khẩu không đúng"
     users_not_allowed: "Xin lỗi bạn, chỉ có admin mới có quyền truy cập tính năng này"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
       get "login", to: "sessions#new"
       post "login", to: "sessions#create"
       get "logout", to: "sessions#destroy"
+      resources :orders, except: %i(create destroy)
     end
     root "static_pages#index"
     get "/home", to: "static_pages#index"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -10,7 +10,7 @@ length:
   digit_9: 9
   featured_products:
     max: 12
-will_paginate:
+paginate:
   per_page: 12
 seeder:
   description_paragraphs: 1


### PR DESCRIPTION
## Related Tickets
- [#43824](https://edu-redmine.sun-asterisk.vn/issues/43824)

## WHAT
- Thêm tính năng admin xem danh sách order trong database.

## HOW
- Thêm controller `orders_controller` và action `index` lấy các order trong db và được paginated.

## WHY
- Cung cấp giao diện cho admin xem và quản lý order.

## Evidence (Screenshot or Video
- Passed rubocop: ![passed-rubocop](https://user-images.githubusercontent.com/91654386/143568133-44059288-dc4d-44b6-8632-b6f523f21934.png)
)
