### PR TITLE
Fix languages dropdon styles, fix seeds file, fix Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem "strings-case"
 gem "turbolinks", "~> 5"
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem "webpacker", "~> 5.0"
+gem "faker"
 
 group :development, :test do
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]
@@ -29,7 +30,6 @@ group :development, :test do
   gem "rubocop-rails", "~> 2.3.2", require: false
 
   # db: mysql2
-  gem "faker"
   gem "mysql2"
 end
 

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -1,4 +1,4 @@
 @import "admin/vendor/fontawesome-free/css/all.css";
 @import "admin/vendor/bootstrap/css/bootstrap.css";
 @import "admin/css/ruang-admin.css";
-@import "admin/custom.scss";
+@import "admin/custom.css";

--- a/app/assets/stylesheets/admin/custom.css
+++ b/app/assets/stylesheets/admin/custom.css
@@ -2,3 +2,10 @@
   -webkit-box-shadow: none;
   box-shadow: none;
 }
+
+.list-languages {
+  padding-left: 0;
+  list-style-type: none;
+  margin-bottom: 0;
+}
+

--- a/app/views/admin/sessions/base.html.erb
+++ b/app/views/admin/sessions/base.html.erb
@@ -16,13 +16,15 @@
         <div class="col-xl-6 col-lg-12 col-md-9">
           <div class="card shadow-sm my-5">
             <div class="card-body p-0">
-              <div class="row p-3">
-                <div class="dropdown show ml-auto">
-                  <div class="dropdown-toggle" role="button" id="dropdownMenuLink" data-toggle="dropdown">
-                    <%= Settings.languages[I18n.locale] %>
-                  </div>
-                  <div id="dropdownMenuLink" class="dropdown-list dropdown-menu shadow">
-                    <%= render "shared/list_languages" %>
+              <div class="row container justify-content-end pt-3">
+                <div>
+                  <div class="dropdown show">
+                    <div class="dropdown-toggle" role="button" id="dropdownMenuLink" data-toggle="dropdown">
+                      <%= Settings.languages[I18n.locale] %>
+                    </div>
+                    <div id="dropdownMenuLink" class="dropdown-list dropdown-menu shadow">
+                      <%= render "shared/list_languages" %>
+                    </div>
                   </div>
                 </div>
               </div>

--- a/app/views/shared/_list_languages.html.erb
+++ b/app/views/shared/_list_languages.html.erb
@@ -1,5 +1,5 @@
 <ul class="list-languages">
   <% I18n.available_locales.each do |lang| %>
-    <a class="dropdown-item" href="<%= change_path_locale request.path, lang %>"><%= Settings.languages[lang] %></a>
+    <li><a class="dropdown-item" href="<%= change_path_locale request.path, lang %>"><%= Settings.languages[lang] %></a></li>
   <% end %>
 </ul>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,7 +7,7 @@ class Seeder
     def sym_to_name sym
       sym = sym.to_s
       sym[0] = sym[0].upcase
-      sym.sub "_", " "
+      sym.sub! "_", " "
       sym
     end
 
@@ -118,7 +118,7 @@ class Seeder
     end
 
     def seed_order_items order
-      offset = rand(User.count)
+      offset = rand(User.where(role: :user).count)
       order.order_items.create product: Product.offset(offset).first,
                               quantity: Faker::Number.between(
                                 from: Settings.seeder.digit.quantity.min,
@@ -127,7 +127,7 @@ class Seeder
     end
 
     def seed_orders_order_items
-      User.find_each do |user|
+      User.where(role: :user).find_each do |user|
         orders_count.times do
           order = user.orders.create
           order_items_count.times do


### PR DESCRIPTION
## Related Tickets
- [#43831](https://edu-redmine.sun-asterisk.vn/issues/43831)

## WHAT (optional)
1. Sửa lại style của language dropdown trang user.
2. Fix seeds file.
3. Sửa Gemfile

## HOW
1. Sửa lại style của language dropdown trang user
2. Fix seeds file:
    - Sửa seed tên category để bỏ dấu gạch dưới
    - Sửa seed order để không tạo order cho tài khoản admin
3. Đưa gem faker vào cài cho mọi environment: chuyển dòng gem "faker" ra scope ngoài cùng.

## WHY
- Sau khi refactor language dropdown thành partial view thì style cần chỉnh lại.
- Seeds files tạo category name thừa dấu `_`, và fake cả data order cho tài khoản admin.
- Cần dùng gem faker ở production

## Evidence (Screenshot or Video)
- Passed rubocop
![passed-rubocop](https://user-images.githubusercontent.com/91654386/143783235-90af873f-8586-49b5-a104-4b9300eca9f4.png)
: 