### PR TITLE
Use Ransack to filter products

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,3 +61,5 @@ end
 gem "figaro", "~> 1.2"
 
 gem "rails-controller-testing", "~> 1.0"
+
+gem "ransack", "~> 2.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -231,6 +231,10 @@ GEM
       thor (~> 1.0)
     rainbow (3.0.0)
     rake (13.0.6)
+    ransack (2.4.2)
+      activerecord (>= 5.2.4)
+      activesupport (>= 5.2.4)
+      i18n
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -355,6 +359,7 @@ DEPENDENCIES
   rails (~> 6.1.4, >= 6.1.4.1)
   rails-controller-testing (~> 1.0)
   rails-i18n
+  ransack (~> 2.4)
   rspec-rails (~> 4.0.1)
   rubocop (~> 0.74.0)
   rubocop-checkstyle_formatter

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,5 +1,5 @@
 class ProductsController < ApplicationController
-  before_action :prepare_category_ids, :filter_products, only: :index
+  before_action :filter_products, only: :index
   before_action :load_product_or_redirect, :related_products, only: :show
 
   def index
@@ -25,47 +25,7 @@ class ProductsController < ApplicationController
   end
 
   def filter_products
-    @products = Product.search_by_name(filters_value(:name))
-                       .search_by_category(@category_params)
-                       .search_by_range(:rating, range_of(:rating))
-                       .search_by_range(:price, range_of(:price))
-                       .search_by_range(:inventory, range_of(:inventory))
-  end
-
-  def filters_value key
-    params[:filters]&.fetch(key, nil)
-  end
-
-  def range_of name
-    return if (value = filters_value(name)).nil?
-
-    {min: value[:min].to_f,
-     max: value[:max].to_f}
-  end
-
-  def prepare_category_ids
-    return unless categories_params_valid?
-
-    @category_params = merge_category_ids(params[:filters][:categories])
-  end
-
-  def categories_params_valid?
-    params.dig(:filters, :categories, :parents) ||
-      params.dig(:filters, :categories, :children)
-  end
-
-  def merge_category_ids categories
-    ids = {}
-    categories[:parents]&.each do |id|
-      next if (category = Category.find_by id: id).nil?
-
-      if category.children.empty?
-        ids[id] = true
-      else
-        category.children.each{|child| ids[child.id] = true}
-      end
-    end
-    categories[:children]&.each{|id| ids[id.to_i] = true}
-    ids.keys
+    @query = Product.ransack(params[:filters])
+    @products = @query.result
   end
 end

--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -1,8 +1,9 @@
 module ProductsHelper
-  def should_checked? id, key
-    return true if params[:filters].blank? ||
-                   params[:filters][:categories].blank?
+  def should_checked? id
+    id_list = params.dig(:filters,
+                         :category_in)
+    return true if id_list.blank?
 
-    params[:filters][:categories][key]&.include?(id.to_s) == true
+    id_list.include?(id.to_s)
   end
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -11,6 +11,7 @@ class Product < ApplicationRecord
 
   belongs_to :category
   delegate :title, to: :category, prefix: :category
+  ransack_alias :category, :category_id_or_category_parent_id
   scope :featured_products,
         (lambda do |max|
           order(rating: :desc).limit(max)

--- a/app/views/layouts/_hero.html.erb
+++ b/app/views/layouts/_hero.html.erb
@@ -12,7 +12,7 @@
             <% parent_categories.each do |category| %>
               <li class="toggle-down-wrapper">
                 <div>
-                  <h4 class="d-inline-block"><%= link_to category.title, products_path(filters: {categories:{parents:[category.id.to_s]}}) %></h4>
+                  <h4 class="d-inline-block"><%= link_to category.title, products_path(filters: {category_in:[category.id.to_s]}) %></h4>
                   <% if category.children.any? %>
                     <span class="fas fa-angle-down toggle-down-main clickable"></span>
                   <% end %>
@@ -21,7 +21,7 @@
                   <ul class="toggle-down-content border-success">
                     <% category.children.each do |subcategory| %>
                       <li>
-                        <h5><%= link_to subcategory.title, products_path(filters: {categories:{children:[subcategory.id.to_s]}}) %></h5>
+                        <h5><%= link_to subcategory.title, products_path(filters: {category_in:[subcategory.id.to_s]}) %></h5>
                       </li>
                     <% end %>
                   </ul>
@@ -38,7 +38,7 @@
               <div class="hero__search__categories">
                 <%= t "labels.category.all" %>
               </div>
-              <%= f.text_field :name, placeholder: t(".what_do_you_need?") %>
+              <%= f.text_field :name_cont, placeholder: t(".what_do_you_need?") %>
               <%= f.button t(".search_btn_txt"), name: nil, class: "site-btn"%>
             <% end %>
           </div>

--- a/app/views/products/_range_input_tag.html.erb
+++ b/app/views/products/_range_input_tag.html.erb
@@ -1,20 +1,19 @@
 <%
   key = to_snakecase(heading).to_sym
-  values = params[:filters]&.fetch(key, nil) || {}
 %>
 <h4><%= t "activerecord.attributes.product.#{key}" %></h4>
 <div class="price-range-wrap">
   <div class="price-range"
         data-min="<%= min %>"
         data-max="<%= max %>"
-        data-start="<%= values.fetch :min, min %>"
-        data-end="<%= values.fetch :max, max %>"
+        data-start="<%= params.dig(:filters,"#{key}_gteq".to_sym) || min %>"
+        data-end="<%= params.dig(:filters,"#{key}_lteq".to_sym) || max %>"
         data-step="<%= step %>">
   </div>
   <div class="range-slider">
     <div class="price-input">
-      <%= f.text_field "#{key}[min]", class: "to-int" %>
-      <%= f.text_field "#{key}[max]", class: "to-int" %>
+      <%= f.text_field "#{key}_gteq", class: "to-int" %>
+      <%= f.text_field "#{key}_lteq", class: "to-int" %>
     </div>
   </div>
 </div>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -20,13 +20,13 @@
               <ul class="category-hierachy toggle-down-content">
                 <% parent_categories.each do |category| %>
                   <li class="form-check">
-                    <%= f.check_box "categories[parents]", {multiple: true, checked: should_checked?(category.id, "parents"), id: "filters_category_#{category.id}", class: "parent-category"}, category.id, nil %>
+                    <%= f.check_box "category_in", {multiple: true, checked: should_checked?(category.id), id: "filters_category_#{category.id}", class: "parent-category"}, category.id, nil %>
                     <%= f.label "category_#{category.id}", category.title %>
                     <% if category.children.length > 0 %>
                       <ul class="border-success">
                         <% category.children.each do |subcategory| %>
                           <li>
-                            <%= f.check_box "categories[children]", {multiple: true, checked: should_checked?(subcategory.id, "children"), id: "filters_category_#{subcategory.id}", class: "subcategory"}, subcategory.id, nil %>
+                            <%= f.check_box "category_in", {multiple: true, checked: should_checked?(subcategory.id), id: "filters_category_#{subcategory.id}", class: "subcategory"}, subcategory.id, nil %>
                             <%= f.label "category_#{subcategory.id}", subcategory.title %>
                           </li>
                         <% end %>


### PR DESCRIPTION
## Related Tickets
- [#44120](https://edu-redmine.sun-asterisk.vn/issues/44120)

## WHAT
1. Sử dụng gem Ransack để thực hiện chức năng filter product thay cho cách xử lý thủ công như trước
2. Sử dụng điều kiện OR để tìm theo category sản phẩm
3. Cập nhật RSpec
## HOW
1.
    - Add gem `ransack`
    - Thay các thuộc tính `name` của các input cho đúng với condition của ransack.
    - Dùng ransack trong controller để lọc products theo filters param.
2. Ở trang index products dùng điều kiện `category_id_or_category_parent_id_in` để tạo câu truy vấn `WHERE (products.category_id IN (?) OR categories.parent_id IN (?))`.
3. Cập nhật các tham số params theo giống condition của ransack trong RSpec Products controller để pass CI

## Evidence (Screenshot or Video)
- Passed `framgia-ci run --local`:
![Screenshot from 2021-12-13 09-28-09](https://user-images.githubusercontent.com/91654386/145743403-e8564c01-7ad8-4271-ba22-460b055615d1.png)
- Passed RSpec for products controller
![Screenshot from 2021-12-13 09-24-13](https://user-images.githubusercontent.com/91654386/145743407-aaf40eb9-8c78-41eb-81e3-e3dea8ac912b.png)

