### PR TITLE
Added devise for user auth

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,3 +61,5 @@ end
 gem "figaro", "~> 1.2"
 
 gem "rails-controller-testing", "~> 1.0"
+
+gem "devise", "~> 4.8"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,12 @@ GEM
       database_cleaner-core (~> 2.0.0)
     database_cleaner-core (2.0.1)
     deep_merge (1.2.1)
+    devise (4.8.0)
+      bcrypt (~> 3.0)
+      orm_adapter (~> 0.1)
+      railties (>= 4.1.0)
+      responders
+      warden (~> 1.2.3)
     diff-lcs (1.4.4)
     docile (1.4.0)
     dry-configurable (0.13.0)
@@ -174,6 +180,7 @@ GEM
     nokogiri (1.12.5)
       mini_portile2 (~> 2.6.1)
       racc (~> 1.4)
+    orm_adapter (0.5.0)
     parallel (1.21.0)
     parser (3.0.2.0)
       ast (~> 2.4.1)
@@ -235,6 +242,9 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     regexp_parser (2.1.1)
+    responders (3.0.1)
+      actionpack (>= 5.0)
+      railties (>= 5.0)
     rexml (3.2.5)
     rspec-core (3.10.1)
       rspec-support (~> 3.10.0)
@@ -309,6 +319,8 @@ GEM
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     unicode-display_width (1.6.1)
+    warden (1.2.9)
+      rack (>= 2.0.9)
     web-console (4.1.0)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
@@ -340,6 +352,7 @@ DEPENDENCIES
   capybara (>= 3.26)
   config
   database_cleaner-active_record
+  devise (~> 4.8)
   factory_bot_rails
   faker
   figaro (~> 1.2)

--- a/app/controllers/admin/sessions_controller.rb
+++ b/app/controllers/admin/sessions_controller.rb
@@ -11,7 +11,7 @@ class Admin::SessionsController < Admin::BaseController
     if @current_user&.user?
       flash[:warning] = t("admin.users_not_allowed")
       redirect_to action: :new
-    elsif @current_user&.authenticate(params[:login][:password])
+    elsif @current_user&.valid_password?(params[:login][:password])
       handle_log_in
     else
       flash[:danger] = t("admin.log_in_failed")

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,5 +5,6 @@ class ApplicationController < ActionController::Base
   include SessionsHelper
 
   before_action :set_locale, :init_cart
+  helper_method :current_user
   protect_from_forgery with: :exception
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,46 +1,25 @@
-class SessionsController < ApplicationController
-  before_action :use_layout_auth, only: [:new]
-  after_action :empty_cart, only: [:destroy]
+class SessionsController < Devise::SessionsController
+  include ApplicationHelper
+  before_action :use_layout_auth
+  before_action :deny_admins, only: :create
 
   def new
-    redirect_to root_url if current_user.present?
+    super
   end
 
   def create
-    @current_user = User.find_by email: params[:user][:email]
-    if @current_user&.admin?
-      flash[:warning] = t("admins_not_allowed")
-      redirect_to action: :new
-    elsif @current_user&.authenticate(params[:user][:password])
-      handle_log_in
-    else
-      flash[:danger] = t("email_password_invalid")
-      redirect_to action: :new
-    end
+    super
   end
 
   def destroy
-    if current_user.present?
-      session.delete :user_id
-      @current_user = nil
-      flash[:success] = t("logged_out")
-    end
-    redirect_to root_url
+    super
   end
 
-  private
+  def deny_admins
+    user = User.find_by email: params[:user][:email]
+    return if user.nil? || user.user?
 
-  def handle_log_in
-    remember_user
-    flash[:success] = t("logged_in_as", name: @current_user.first_name)
-    redirect_to root_url
-  end
-
-  def remember_user
-    session[:user_id] = @current_user.id
-  end
-
-  def use_layout_auth
-    @use_layout_auth = true
+    flash[:warning] = t("admins_not_allowed")
+    render :new
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -27,4 +27,8 @@ module ApplicationHelper
   def set_locale
     I18n.locale = params[:locale] || I18n.default_locale
   end
+
+  def use_layout_auth
+    @use_layout_auth = true
+  end
 end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -1,9 +1,13 @@
 module SessionsHelper
-  def current_user
-    @current_user ||= User.find_by id: session[:user_id]
-  end
+  DEVISE_MESSAGE_TYPES = [:notice, :alert].freeze
+  DEVISE_MESSAGE_TYPES_MAPPING = {notice: :info, alert: :danger}.freeze
 
-  def is_logged_in?
-    current_user.present?
+  def use_custom_flash!
+    DEVISE_MESSAGE_TYPES.each do |key|
+      next unless flash.key? key.to_s
+
+      flash[DEVISE_MESSAGE_TYPES_MAPPING[key]] = flash[key]
+      flash.delete key
+    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
+  devise :database_authenticatable
   VALID_EMAIL_REGEX = /\A[\w\-.+]+@[a-z\-\d.]+\.[a-z]+\z/i.freeze
   VALID_TELEPHONE_REGEX = /\A0[\d ]+\z/i.freeze
   before_save{email.downcase!}
@@ -19,7 +20,7 @@ class User < ApplicationRecord
                                  maximum: Settings.length.digit_12},
                         allow_blank: true
   validates :address, length: {maximum: Settings.length.digit_255}
-  has_secure_password
+  validates :current_password, confirmation: true, allow_blank: true
 
   enum role: {user: 0, admin: 1}
   enum gender: {female: false, male: true}

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,4 +1,5 @@
 <div class="sticky-top">
+  <% use_custom_flash! %>
   <% flash.each do |message_type, message| %>
     <div class="alert alert-<%= message_type %>">
       <div class="container">

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -17,10 +17,10 @@
   <div class="header__top__right__auth">
     <% if current_user.present? %>
       <%= link_to "#" do %>
-        <i class="fa fa-user"></i><%= current_user.first_name %>, <%= link_to t(".logout"), logout_path %>
+        <i class="fa fa-user"></i><%= current_user.first_name %>, <%= link_to t(".logout"), destroy_user_session_path %>
       <% end %>
     <% else %>
-      <%= link_to login_path do %>
+      <%= link_to new_user_session_path do %>
         <i class="fa fa-user"></i><%= t ".login" %>
       <% end %>
     <% end %>
@@ -70,10 +70,10 @@
             <div class="header__top__right__auth">
               <% if current_user.present? %>
                 <%= link_to "#" do %>
-                  <i class="fa fa-user"></i><%= current_user.first_name %>, <%= link_to t(".logout"), logout_path %>
+                  <i class="fa fa-user"></i><%= current_user.first_name %>, <%= link_to t(".logout"), destroy_user_session_path %>
                 <% end %>
               <% else %>
-                <%= link_to login_path do %>
+                <%= link_to new_user_session_path do %>
                   <i class="fa fa-user"></i><%= t ".login" %>
                 <% end %>
               <% end %>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,0 +1,27 @@
+Devise.setup do |config|
+  config.mailer_sender = "please-change-me-at-config-initializers-devise@example.com"
+
+  require "devise/orm/active_record"
+
+  config.case_insensitive_keys = [:email]
+
+  config.strip_whitespace_keys = [:email]
+
+  config.skip_session_storage = [:http_auth]
+
+  config.stretches = Rails.env.test? ? 1 : 12
+
+  config.reconfirmable = true
+
+  config.expire_all_remember_me_on_sign_out = true
+
+  config.password_length = 6..128
+
+  config.email_regexp = /\A[^@\s]+@[^@\s]+\z/
+
+  config.reset_password_within = 6.hours
+
+  config.scoped_views = true
+
+  config.sign_out_via = :get
+end

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -1,0 +1,63 @@
+en:
+  devise:
+    confirmations:
+      confirmed: "Your email address has been successfully confirmed."
+      send_instructions: "You will receive an email with instructions for how to confirm your email address in a few minutes."
+      send_paranoid_instructions: "If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes."
+    failure:
+      already_authenticated: "You are already signed in."
+      inactive: "Your account is not activated yet."
+      invalid: "Invalid %{authentication_keys} or password."
+      locked: "Your account is locked."
+      last_attempt: "You have one more attempt before your account is locked."
+      not_found_in_database: "Invalid %{authentication_keys} or password."
+      timeout: "Your session expired. Please sign in again to continue."
+      unauthenticated: "You need to sign in or sign up before continuing."
+      unconfirmed: "You have to confirm your email address before continuing."
+    mailer:
+      confirmation_instructions:
+        subject: "Confirmation instructions"
+      reset_password_instructions:
+        subject: "Reset password instructions"
+      unlock_instructions:
+        subject: "Unlock instructions"
+      email_changed:
+        subject: "Email Changed"
+      password_change:
+        subject: "Password Changed"
+    omniauth_callbacks:
+      failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
+      success: "Successfully authenticated from %{kind} account."
+    passwords:
+      no_token: "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."
+      send_instructions: "You will receive an email with instructions on how to reset your password in a few minutes."
+      send_paranoid_instructions: "If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes."
+      updated: "Your password has been changed successfully. You are now signed in."
+      updated_not_active: "Your password has been changed successfully."
+    registrations:
+      destroyed: "Bye! Your account has been successfully cancelled. We hope to see you again soon."
+      signed_up: "Welcome! You have signed up successfully."
+      signed_up_but_inactive: "You have signed up successfully. However, we could not sign you in because your account is not yet activated."
+      signed_up_but_locked: "You have signed up successfully. However, we could not sign you in because your account is locked."
+      signed_up_but_unconfirmed: "A message with a confirmation link has been sent to your email address. Please follow the link to activate your account."
+      update_needs_confirmation: "You updated your account successfully, but we need to verify your new email address. Please check your email and follow the confirmation link to confirm your new email address."
+      updated: "Your account has been updated successfully."
+      updated_but_not_signed_in: "Your account has been updated successfully, but since your password was changed, you need to sign in again."
+    sessions:
+      signed_in: "Signed in successfully."
+      signed_out: "Signed out successfully."
+      already_signed_out: "Signed out successfully."
+    unlocks:
+      send_instructions: "You will receive an email with instructions for how to unlock your account in a few minutes."
+      send_paranoid_instructions: "If your account exists, you will receive an email with instructions for how to unlock it in a few minutes."
+      unlocked: "Your account has been unlocked successfully. Please sign in to continue."
+  errors:
+    messages:
+      already_confirmed: "was already confirmed, please try signing in"
+      confirmation_period_expired: "needs to be confirmed within %{period}, please request a new one"
+      expired: "has expired, please request a new one"
+      not_found: "not found"
+      not_locked: "was not locked"
+      not_saved:
+        one: "1 error prohibited this %{resource} from being saved:"
+        other: "%{count} errors prohibited this %{resource} from being saved:"

--- a/config/locales/devise.vi.yml
+++ b/config/locales/devise.vi.yml
@@ -1,0 +1,20 @@
+vi:
+  devise:
+    failure:
+      already_authenticated: "Người dùng đã đăng nhập."
+      invalid: "%{authentication_keys} hoặc mật khẩu không hợp lệ."
+      not_found_in_database: "%{authentication_keys} hoặc mật khẩu không hợp lệ."
+      unauthenticated: "Xin hãy đăng nhập."
+    registrations:
+      updated: "Cập nhật tài khoản thành công."
+      signed_up: "Đăng ký tài khoản thành công."
+    sessions:
+      signed_in: "Đăng nhập thành công."
+      signed_out: "Đăng xuất thành công."
+      already_signed_out: "Đã đăng xuất khỏi tài khoản."
+  errors:
+    messages:
+      not_found: "không tồn tại"
+      not_saved:
+        one: "1 lỗi khiến %{resource} không thể lưu thành công:"
+        other: "%{count} lỗi khiến %{resource} không thể lưu thành công:"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,13 +7,12 @@ Rails.application.routes.draw do
       get "logout", to: "sessions#destroy"
       resources :orders, except: %i(create destroy)
     end
+    devise_for :users, controllers: {sessions: "sessions"},
+                       path: "",
+                       path_names: {sign_in: :login, sign_out: :logout,
+                                    sign_up: :register}
     root "static_pages#index"
     get "/home", to: "static_pages#index"
-
-    get "/login", to: "sessions#new"
-    post "/login", to: "sessions#create"
-    get "/logout", to: "sessions#destroy"
-
     resources :products, only: %i(index show)
     resources :carts, except: %i(new show edit)
     resources :orders, only: %i(new create)

--- a/db/migrate/20211220195204_add_devise_user.rb
+++ b/db/migrate/20211220195204_add_devise_user.rb
@@ -1,0 +1,6 @@
+class AddDeviseUser < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :encrypted_password, :string,
+               null: false, default: ""
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_09_030517) do
+ActiveRecord::Schema.define(version: 2021_12_20_195204) do
 
   create_table "categories", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "parent_id"
@@ -66,6 +66,7 @@ ActiveRecord::Schema.define(version: 2021_11_09_030517) do
     t.string "remember_digest"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "encrypted_password", default: "", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -70,7 +70,6 @@ RSpec.describe User, type: :model do
       end
     end
     describe "password" do
-      it{should have_secure_password}
       it do
         should validate_length_of(:password)
           .is_at_least(Settings.length.digit_8)


### PR DESCRIPTION
## Related Tickets
- [#44402](https://edu-redmine.sun-asterisk.vn/issues/44402)

## WHAT
- Xử lý đăng xuất, đăng nhập user bằng gem devise thay vì xử lý thủ công như trước

## HOW
- Add gem `devise`
- Tạo các route sử dụng devise scope user và đổi tên route cho giống như cũ (/login, /logout)
- Cập nhật session controller cho kế thừa từ `Devise::SessionController`
- Cập nhật RSpec cho user sessions controller theo logic của devise để pass CI
- Sửa hàm `authenticate` của `bcrypt` thành hàm `valid_password?` của devise trong `Admin::SessionsController`

## Evidence (Screenshot or Video)
- Passed `framgia-ci run --local`
![Screenshot from 2021-12-20 16-41-30](https://user-images.githubusercontent.com/91654386/146746406-1da23b9d-b7fb-42b6-8815-cc5b7ef43ec2.png)

