### PR TITLE
Added auth api

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ group :development, :test do
 
   # db: mysql2
   gem "mysql2"
+  gem "grape_on_rails_routes", "~> 0.3.2"
 end
 
 group :development do
@@ -61,3 +62,14 @@ end
 gem "figaro", "~> 1.2"
 
 gem "rails-controller-testing", "~> 1.0"
+
+gem "grape", "~> 1.6"
+
+gem "grape-swagger", "~> 1.4"
+gem "grape-swagger-rails", "~> 0.3.1"
+
+gem "rack-cors", "~> 1.1"
+
+gem "jwt", "~> 2.3"
+
+gem "grape-route-helpers", "~> 2.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,11 +137,29 @@ GEM
       thor (>= 0.14.0, < 2)
     globalid (0.5.2)
       activesupport (>= 5.0)
+    grape (1.6.0)
+      activesupport
+      builder
+      dry-types (>= 1.1)
+      mustermann-grape (~> 1.0.0)
+      rack (>= 1.3.0)
+      rack-accept
+    grape-route-helpers (2.1.0)
+      activesupport
+      grape (>= 0.16.0)
+      rake
+    grape-swagger (1.4.2)
+      grape (~> 1.3)
+    grape-swagger-rails (0.3.1)
+      railties (>= 3.2.12)
+    grape_on_rails_routes (0.3.2)
+      rails (>= 3.1.1)
     i18n (1.8.11)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
     jbuilder (2.11.2)
       activesupport (>= 5.0.0)
+    jwt (2.3.0)
     kaminari (1.2.1)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.2.1)
@@ -169,6 +187,10 @@ GEM
     mini_portile2 (2.6.1)
     minitest (5.14.4)
     msgpack (1.4.2)
+    mustermann (1.1.1)
+      ruby2_keywords (~> 0.0.1)
+    mustermann-grape (1.0.1)
+      mustermann (>= 1.0.0)
     mysql2 (0.5.3)
     nio4r (2.5.8)
     nokogiri (1.12.5)
@@ -190,6 +212,10 @@ GEM
       nio4r (~> 2.0)
     racc (1.6.0)
     rack (2.2.3)
+    rack-accept (0.4.5)
+      rack (>= 0.4)
+    rack-cors (1.1.1)
+      rack (>= 2.0.0)
     rack-mini-profiler (2.3.3)
       rack (>= 1.2.0)
     rack-proxy (0.7.0)
@@ -266,6 +292,7 @@ GEM
       rack (>= 1.1)
       rubocop (>= 0.72.0)
     ruby-progressbar (1.11.0)
+    ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
@@ -343,7 +370,13 @@ DEPENDENCIES
   factory_bot_rails
   faker
   figaro (~> 1.2)
+  grape (~> 1.6)
+  grape-route-helpers (~> 2.1)
+  grape-swagger (~> 1.4)
+  grape-swagger-rails (~> 0.3.1)
+  grape_on_rails_routes (~> 0.3.2)
   jbuilder (~> 2.7)
+  jwt (~> 2.3)
   kaminari
   listen (~> 3.3)
   mysql2
@@ -351,6 +384,7 @@ DEPENDENCIES
   pry-nav
   pry-rails
   puma (~> 5.0)
+  rack-cors (~> 1.1)
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.4, >= 6.1.4.1)
   rails-controller-testing (~> 1.0)

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,2 +1,4 @@
 //= link_tree ../images
 //= link_directory ../stylesheets .css
+//= link grape_swagger_rails/application.js
+//= link grape_swagger_rails/application.css

--- a/app/controllers/api/root.rb
+++ b/app/controllers/api/root.rb
@@ -1,0 +1,5 @@
+module API
+  class Root < Grape::API
+    mount API::V1::Root
+  end
+end

--- a/app/controllers/api/v1/auth.rb
+++ b/app/controllers/api/v1/auth.rb
@@ -1,0 +1,28 @@
+module API
+  module V1
+    class Auth < Grape::API
+      include API::V1::SharedConcern
+
+      desc "Log in with email, password and return "\
+           "a bearer authentication token",
+           tags: %w(Auth),
+           http_codes: [
+             {code: 201, message: "Login successfully"},
+             {code: 422, message: "Request contain invalid data"},
+             {code: 500, message: "Server error"}
+           ]
+      params do
+        requires :email, type: String, documentation: {in: "body"}
+        requires :password, type: String, documentation: {in: "body"}
+      end
+      post "login" do
+        user = User.find_by email: params[:email]
+        if user&.authenticate params[:password]
+          {token: Services::Authentication.sign(user_id: user.id)}
+        else
+          error!(I18n.t("grape.errors.messages.invalid_email_password"), 401)
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/root.rb
+++ b/app/controllers/api/v1/root.rb
@@ -1,0 +1,14 @@
+module API
+  module V1
+    class Root < Grape::API
+      mount API::V1::Auth
+
+      add_swagger_documentation(
+        api_version: "v1",
+        hide_documentation_path: true,
+        mount_path: Settings.swagger_doc_path,
+        hide_format: true
+      )
+    end
+  end
+end

--- a/app/controllers/concerns/api/v1/shared_concern.rb
+++ b/app/controllers/concerns/api/v1/shared_concern.rb
@@ -1,0 +1,39 @@
+module API
+  module V1
+    module SharedConcern
+      extend ActiveSupport::Concern
+
+      included do
+        prefix "api"
+        version "v1", using: :path
+        default_format :json
+        format :json
+
+        rescue_from ActiveRecord::RecordNotFound do |e|
+          error_response(message: e.message, status: 404)
+        end
+
+        rescue_from ActiveRecord::RecordInvalid do |e|
+          error_response(message: e.message, status: 422)
+        end
+
+        rescue_from Grape::Exceptions::ValidationErrors do |e|
+          error_response(message: e.message, status: 422)
+        end
+
+        rescue_from Grape::Exceptions::InvalidMessageBody do |e|
+          error_response(message: e.message, status: 400)
+        end
+
+        rescue_from :all do |e|
+          message = if Rails.env.production?
+                      e.message
+                    else
+                      {message: e.message, type: e.class}
+                    end
+          error_response(message: message, status: 500)
+        end
+      end
+    end
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -37,5 +37,6 @@ module DnInternTungLaiEcommerce
       authentication: "plain",
       enable_starttls_auto: true
     }
+    config.autoload_paths << "lib"
   end
 end

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -1,0 +1,7 @@
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins "*"
+    resource "*", headers: :any, methods: [:get,
+      :post, :put, :delete, :options]
+  end
+end

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -3,12 +3,13 @@
 # Add new inflection rules using the following format. Inflections
 # are locale specific, and you may define rules for as many different
 # locales as you wish. All of these examples are active by default:
-# ActiveSupport::Inflector.inflections(:en) do |inflect|
-#   inflect.plural /^(ox)$/i, '\1en'
-#   inflect.singular /^(ox)en/i, '\1'
-#   inflect.irregular 'person', 'people'
-#   inflect.uncountable %w( fish sheep )
-# end
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.acronym "API"
+  # inflect.plural /^(ox)$/i, '\1en'
+  # inflect.singular /^(ox)en/i, '\1'
+  # inflect.irregular 'person', 'people'
+  # inflect.uncountable %w( fish sheep )
+end
 
 # These inflection rules are supported but not enabled by default:
 # ActiveSupport::Inflector.inflections(:en) do |inflect|

--- a/config/initializers/swagger.rb
+++ b/config/initializers/swagger.rb
@@ -1,0 +1,2 @@
+GrapeSwaggerRails.options.url = Settings.swagger_doc_path
+GrapeSwaggerRails.options.app_url = Settings.host

--- a/config/locales/grape.en.yml
+++ b/config/locales/grape.en.yml
@@ -1,0 +1,5 @@
+en:
+  grape:
+    errors:
+      messages:
+        invalid_email_password: "Invalid email or password"

--- a/config/locales/grape.vi.yml
+++ b/config/locales/grape.vi.yml
@@ -1,0 +1,55 @@
+vi:
+  grape:
+    errors:
+      format: ! "%{attributes} %{message}"
+      messages:
+        invalid_email_password: "Địa chỉ email hoặc mật khẩu không hợp lệ"
+        coerce: "không hợp lệ"
+        presence: "bị thiếu"
+        regexp: "không hợp lệ"
+        blank: "bị trống"
+        values: "chứa giá trị không hợp lệ"
+        except_values: "chứa giá trị không cho phép"
+        same_as: "không giống với %{parameter}"
+        missing_vendor_option:
+          problem: "thiếu lựa chọn :vendor."
+          summary: "when version using header, you must specify :vendor option. "
+          resolution: "eg: version "v1", using: :header, vendor: "twitter""
+        missing_mime_type:
+          problem: "missing mime type for %{new_format}"
+          resolution:
+            "you can choose existing mime type from Grape::ContentTypes::CONTENT_TYPES
+            or add your own with content_type :%{new_format}, "application/%{new_format}"
+            "
+        invalid_with_option_for_represent:
+          problem: "You must specify an entity class in the :with option."
+          resolution: "eg: represent User, :with => Entity::User"
+        missing_option: "You must specify :%{option} options."
+        invalid_formatter: "cannot convert %{klass} to %{to_format}"
+        invalid_versioner_option:
+          problem: "Unknown :using for versioner: %{strategy}"
+          resolution: "available strategy for :using is :path, :header, :accept_version_header, :param"
+        unknown_validator: "unknown validator: %{validator_type}"
+        unknown_options: "unknown options: %{options}"
+        unknown_parameter: "unknown parameter: %{param}"
+        incompatible_option_values: "%{option1}: %{value1} is incompatible with %{option2}: %{value2}"
+        mutual_exclusion: "are mutually exclusive"
+        at_least_one: "are missing, at least one parameter must be provided"
+        exactly_one: "are missing, exactly one parameter must be provided"
+        all_or_none: "provide all or none of parameters"
+        missing_group_type: "group type is required"
+        unsupported_group_type: "group type must be Array, Hash, JSON or Array[JSON]"
+        invalid_message_body:
+          problem: "message body does not match declared format"
+          resolution:
+            "when specifying %{body_format} as content-type, you must pass valid
+            %{body_format} in the request"s "body"
+            "
+        empty_message_body: "Empty message body supplied with %{body_format} content-type"
+        invalid_accept_header:
+          problem: "Invalid accept header"
+          resolution: "%{message}"
+        invalid_version_header:
+          problem: "Invalid version header"
+          resolution: "%{message}"
+        invalid_response: "Invalid response"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
   scope "(:locale)", locale: /#{I18n.available_locales.join("|")}/ do
+    mount API::Root, at: "/"
+    mount GrapeSwaggerRails::Engine, at: "/api-docs"
     namespace :admin do
       root "static_pages#index"
       get "login", to: "sessions#new"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -50,3 +50,6 @@ digit:
   zero: 0
 mailer:
   from: "noreply@tlshop.com"
+host: "http://localhost:3000"
+swagger_doc_path: "/api/v1/swagger_doc"
+token_secret: "bloomingseed"

--- a/lib/services/authentication.rb
+++ b/lib/services/authentication.rb
@@ -1,0 +1,18 @@
+require "jwt"
+
+module Services
+  class Authentication
+    ALGORITHM = "HS256".freeze
+
+    class << self
+      def sign payload
+        JWT.encode(payload, Settings.token_secret, ALGORITHM)
+      end
+
+      def verify payload
+        JWT.decode(payload, Settings.token_secret, true, algorithm: ALGORITHM)
+           .first
+      end
+    end
+  end
+end

--- a/spec/controllers/api/v1/auth_spec.rb
+++ b/spec/controllers/api/v1/auth_spec.rb
@@ -1,0 +1,70 @@
+require "rails_helper"
+
+def grape_error attribute, message_type
+  I18n.t("grape.errors.format", attributes: attribute,
+  message:  I18n.t("grape.errors.messages.#{message_type}"))
+end
+
+RSpec.context API::V1::Root, type: :request do
+  include GrapeRouteHelpers::NamedRouteMatcher
+
+  describe "POST #login" do
+    let(:user){create :user}
+    before(:each) do
+      post api_v1_login_path, params: params, as: :json
+      @response_body = JSON.parse(response.body, symbolize_names: true)
+    end
+
+    context "when valid email and password combination" do
+      let(:params){{email: user.email, password: user.password}}
+
+      it "should return authentication token" do
+        expect(@response_body[:token].blank?).to be false
+      end
+      it "should have successful response code" do
+        expect(response).to have_http_status(201)
+      end
+    end
+
+    context "when email is not included in request body" do
+      let(:params){{password: user.password}}
+
+      it "should response with error response code" do
+        expect(response).to have_http_status(422)
+      end
+      it "should response with error message" do
+        expect(@response_body[:error]).to eq(grape_error("email", "presence"))
+      end
+    end
+    context "when password is not included in request body" do
+      let(:params){{email: user.email}}
+
+      it "should response with  error response code" do
+        expect(response).to have_http_status(422)
+      end
+      it "should response with error message" do
+        expect(@response_body[:error]).to eq(grape_error("password", "presence"))
+      end
+    end
+    context "when email and password are not included in request body" do
+      let(:params){{}}
+
+      it "should response with  error response code" do
+        expect(response).to have_http_status(422)
+      end
+      it "should response with error message" do
+        errors = [grape_error("email", "presence"), grape_error("password", "presence")]
+        expect(@response_body[:error]).to eq(errors.join(", "))
+      end
+    end
+    context "when invalid email and password combination" do
+      let(:params){{email: user.email, password: user.password + "123"}}
+      it "should return error response code" do
+        expect(response).to have_http_status(401)
+      end
+      it "should return error message" do
+        expect(@response_body[:error]).to eq(I18n.t("grape.errors.messages.invalid_email_password"))
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Related Tickets
- [#44456](https://edu-redmine.sun-asterisk.vn/issues/44456)

## WHAT
1. Tạo route thực hiện chức năng  đăng nhập và trả về JWT Token
2. Viết RSpec cho route đó
3. Viết api documentation cho route đó
## HOW
1.
    - Tạo thư mục chứa code api ở `app/controllers/api` và `app/controllers/api/v1`, concern ở `app/controllers/concerns/api/v1` theo tên module `API` và `API::V1`
    - Sử dụng gem `grape` để viết API endpoints bằng Grape::API
    - Tạo các file api: `root.rb`, `v1/root.rb`, `v1/auth.rb`
    - Sử dụng gem `jwt` để xử lý tạo, xác thực jwt token
    - Tạo service authentication để xử lý code về jwt ở file `lib/services/authentication.rb`, và thêm `lib/services` vào `config.autoload_paths`
    - Phiên dịch một phần thông báo lỗi của Grape và thông báo success của API ở file `config/locales/grape.vi.yml`
    - Thiết lập CORS cho mọi origin và method bằng gem `rake-cors` và file `config/initializers/cors.rb`
2.
    - Sử dụng gem `grape-route-helpers` để dễ viết RSpec hơn
3. 
    - Sử dụng gem `grape-swagger` để viết API doc trong file `auth.rb` và compile ra file API documentation
    - Sử dụng gem `grape-swagger-rails` để render trang SwaggerUI để xem api doc và chạy thử endpoint

## Evidence (Screenshot or Video)
- SwaggerUI hiển thị API documentation
![Screenshot from 2021-12-22 11-28-54](https://user-images.githubusercontent.com/91654386/147035798-c3d944cc-3353-4a21-9dec-b892d319ad78.png)
- Pass `framgia-ci run --local`
![Screenshot from 2021-12-22 11-31-05](https://user-images.githubusercontent.com/91654386/147035866-31a5249d-fd5b-47fb-9136-1b97383a5ec8.png)

